### PR TITLE
Add Makefile for Hugo site generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+HUGO := hugo
+BASE_URL ?=
+DESTINATION := docs
+
+ARGS := --minify --destination $(DESTINATION)
+ifneq ($(BASE_URL),)
+	ARGS += --baseURL $(BASE_URL)
+endif
+
+.PHONY: all build serve clean help
+
+all: build
+
+build: ## Build the site. Usage: make build [BASE_URL=https://example.com/]
+	$(HUGO) $(ARGS)
+
+serve: ## Serve the site locally with drafts enabled.
+	$(HUGO) server -D
+
+clean: ## Clean the build directory.
+	rm -rf $(DESTINATION)
+
+help: ## Show this help message.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
Added a Makefile to simplify Hugo commands for building and serving the site. The `build` target outputs to `docs/` to support GitHub Pages hosting from the main branch.

---
*PR created automatically by Jules for task [16620983222281976244](https://jules.google.com/task/16620983222281976244) started by @josuebrunel*